### PR TITLE
fix: ecoMode enable/disable

### DIFF
--- a/lib/ac.js
+++ b/lib/ac.js
@@ -237,9 +237,10 @@ module.exports = class extends EventEmitter {
             break;
 
           case 'ecoMode':
-            if (status.mode !== 'cool' && properties.mode !== 'cool') {
-              return reject(new errors.OutOfRangeError('ecoMode capability is only available in cool mode'));
-            }
+            // TODO: Doesnt work need to fix, eco is only allowed in cool mode
+            // if (status.mode !== 'cool' && properties.mode !== 'cool') {
+            //   return reject(new errors.OutOfRangeError('ecoMode capability is only available in cool mode'));
+            // }
             
             logger.debug('AC.setStatus: Enable ecoMode');
 

--- a/lib/ac.js
+++ b/lib/ac.js
@@ -236,6 +236,16 @@ module.exports = class extends EventEmitter {
             status.beep = properties[property] === true;
             break;
 
+          case 'ecoMode':
+            if (status.mode !== 'cool' && properties.mode !== 'cool') {
+              return reject(new errors.OutOfRangeError('ecoMode capability is only available in cool mode'));
+            }
+            
+            logger.debug('AC.setStatus: Enable ecoMode');
+
+            status.ecoMode = properties[property] === true;
+            break;
+
           case 'fanSpeed':
             if (typeof properties[property] === 'number') {
               if (properties[property] < 0 || properties[property] > 100) {
@@ -505,7 +515,7 @@ module.exports = class extends EventEmitter {
       // G: exchangeAir/Ventilation (not used?)
       // H: wiseEye/smartEye (not used?)
       cmd[9] = (status.ecoMode ? 0x80 : 0x00) | (status.changeCosySlep ? 0x40 : 0x00) |
-               (status.purify ? 0x40 : 0x00) | (status.ptcButton ? 0x10 : 0x00) |
+               (status.purify ? 0x20 : 0x00) | (status.ptcButton ? 0x10 : 0x00) |
                (status.ptcHeater ? 0x08 : 0x00) | (status.dryClean ? 0x04 : 0x00) |
                (status.ventilation ? 0x02 : 0x00) | (status.smartEye ? 0x01 : 0x00);
 


### PR DESCRIPTION
It wasn't possible to enable/disable ecoMode, so fixes it.
TODO: Need to add check if current mode is cool mode, because ecoMode works only when cool mode is enabled. Currently commented out code doesn't work, but still, you can turn on/off ecoMode as long as it's in cool mode.